### PR TITLE
Energy broadening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">= 3.10"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
 
-dependencies = ["ase >= 3.23.0", "typer", "joblib"]
+dependencies = ["ase >= 3.23.0", "typer", "joblib", "scipy"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
Introduce some functions that produce batches of modes for energy bins.

Unlike the "indices" approach, here the assignment of modes to bins includes some broadening in the form of Gaussian distribution. Note that there is still a random thermal amplitude involved, so we may need more samples in order to get really smooth tails on these.